### PR TITLE
Add Mercurial support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
       <type>jar</type>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.scm</groupId>
+      <artifactId>maven-scm-provider-hg</artifactId>
+      <version>1.7</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>2.0</version>

--- a/src/main/java/org/sonar/plugins/scmstats/ScmStatsSensor.java
+++ b/src/main/java/org/sonar/plugins/scmstats/ScmStatsSensor.java
@@ -57,7 +57,9 @@ public class ScmStatsSensor implements Sensor {
         List<ChangeSet> changeSets = changeLogScmResult.getChangeLog().getChangeSets();
         ChangeLogHandler holder = new ChangeLogHandler();
         for (ChangeSet changeSet : changeSets) {
-          holder.addChangeLog(changeSet.getAuthor(),changeSet.getDate(),changeSet.getRevision());
+          if (changeSet.getAuthor() != null && changeSet.getDate() != null) {
+            holder.addChangeLog(changeSet.getAuthor(),changeSet.getDate(),changeSet.getRevision());
+          }
         }
         holder.generateMeasures();
         holder.saveMeasures(context);

--- a/src/main/java/org/sonar/plugins/scmstats/SupportedScm.java
+++ b/src/main/java/org/sonar/plugins/scmstats/SupportedScm.java
@@ -22,11 +22,13 @@ package org.sonar.plugins.scmstats;
 
 import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.git.gitexe.GitExeScmProvider;
+import org.apache.maven.scm.provider.hg.HgScmProvider;
 import org.apache.maven.scm.provider.svn.svnexe.SvnExeScmProvider;
 
 public enum SupportedScm {
   SVN(new SvnExeScmProvider()),
-  GIT(new GitExeScmProvider());
+  GIT(new GitExeScmProvider()),
+  HG(new HgScmProvider());
   
   private final ScmProvider provider;
 

--- a/src/test/java/org/sonar/plugins/scmstats/SonarScmManagerTest.java
+++ b/src/test/java/org/sonar/plugins/scmstats/SonarScmManagerTest.java
@@ -21,6 +21,8 @@
 package org.sonar.plugins.scmstats;
 
 import org.apache.maven.scm.manager.NoSuchScmProviderException;
+import org.apache.maven.scm.provider.git.gitexe.GitExeScmProvider;
+import org.apache.maven.scm.provider.hg.HgScmProvider;
 import org.apache.maven.scm.provider.svn.svnexe.SvnExeScmProvider;
 import org.junit.*;
 import static org.junit.Assert.*;
@@ -40,7 +42,16 @@ public class SonarScmManagerTest {
   @Test
   public void testScmManagerGitProvider() {
     try {
-      scmManager.getProviderByType(new SvnExeScmProvider().getScmType());
+      scmManager.getProviderByType(new GitExeScmProvider().getScmType());
+    } catch (NoSuchScmProviderException ex) {
+      fail (ex.getProviderName() + " Provider should be registered" );
+    }
+  }
+
+  @Test
+  public void testScmManagerHgProvider() {
+    try {
+      scmManager.getProviderByType(new HgScmProvider().getScmType());
     } catch (NoSuchScmProviderException ex) {
       fail (ex.getProviderName() + " Provider should be registered" );
     }

--- a/src/test/java/org/sonar/plugins/scmstats/SupportedScmTest.java
+++ b/src/test/java/org/sonar/plugins/scmstats/SupportedScmTest.java
@@ -29,7 +29,7 @@ public class SupportedScmTest {
   @Test
   public void testValues() {
     SupportedScm[] result = SupportedScm.values();
-    assertThat(result.length, equalTo(2));
+    assertThat(result.length, equalTo(3));
   }
 
 }


### PR DESCRIPTION
Tested locally against a decent sized repo. I needed to add a null check in ScmStatsSensor due to problems with maven-scm-provider-hg returing ChangeSet objects with null author fields. I plan to investigate that problem soon and hopefully fix the root cause.
