### PR TITLE
Migrate to Sonar 3.0 Plugin API. Stop using commons-configuration and use org.sonar.api.config.Settings instead.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.codehaus.sonar-plugins</groupId>
     <artifactId>parent</artifactId>
-    <version>13</version>
+    <version>14</version>
   </parent>
   
   <artifactId>sonar-scm-stats-plugin</artifactId>
@@ -51,7 +51,7 @@
   </developers>
   
   <properties>
-    <sonar.minversion>2.13</sonar.minversion>
+    <sonar.minversion>3.0</sonar.minversion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.pluginName>ScmStats</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.scmstats.ScmStatsPlugin</sonar.pluginClass>

--- a/src/main/java/org/sonar/plugins/scmstats/ScmConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scmstats/ScmConfiguration.java
@@ -21,25 +21,25 @@ package org.sonar.plugins.scmstats;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.scm.provider.ScmUrlUtils;
 import org.sonar.api.BatchExtension;
+import org.sonar.api.config.Settings;
 
 public class ScmConfiguration implements BatchExtension {
 
-  private final Configuration configuration;
-  private final MavenScmConfiguration mavenConfonfiguration;
+  private final Settings settings;
+  private final MavenScmConfiguration mavenConfiguration;
   private final Supplier<String> url;
 
-  public ScmConfiguration(Configuration configuration, MavenScmConfiguration mavenConfiguration) {
-    this.configuration = configuration;
-    this.mavenConfonfiguration = mavenConfiguration;
+  public ScmConfiguration(Settings settings, MavenScmConfiguration mavenConfiguration) {
+    this.settings = settings;
+    this.mavenConfiguration = mavenConfiguration;
     url = Suppliers.memoize(new UrlSupplier());
   }
 
-  public ScmConfiguration(Configuration configuration) {
-    this(configuration,null /** not in maven environment*/);
+  public ScmConfiguration(Settings settings) {
+    this(settings,null /** not in maven environment*/);
   }
 
   public String getScmProvider() {
@@ -50,7 +50,7 @@ public class ScmConfiguration implements BatchExtension {
   }
 
   public boolean isEnabled() {
-    return configuration.getBoolean(ScmStatsPlugin.ENABLED, ScmStatsPlugin.ENABLED_DEFAULT);
+    return settings.getBoolean(ScmStatsPlugin.ENABLED);
   }
 
   public String getUrl() {
@@ -65,7 +65,7 @@ public class ScmConfiguration implements BatchExtension {
         return mavenUrl;
       }
 
-      String urlPropertyFromScmActivity = configuration.getString("sonar.scm.url");
+      String urlPropertyFromScmActivity = settings.getString("sonar.scm.url");
       if (!StringUtils.isBlank(urlPropertyFromScmActivity)) {
         return urlPropertyFromScmActivity;
       }
@@ -74,13 +74,13 @@ public class ScmConfiguration implements BatchExtension {
     }
 
     private String getMavenUrl() {
-      if (mavenConfonfiguration == null) {
+      if (mavenConfiguration == null) {
         return null;
       }
 //      if (StringUtils.isNotBlank(mavenConfonfiguration.getDeveloperUrl()) && StringUtils.isNotBlank(getUser())) {
 //        return mavenConfonfiguration.getDeveloperUrl();
 //      }
-      return mavenConfonfiguration.getUrl();
+      return mavenConfiguration.getUrl();
     }
 
   }

--- a/src/test/java/org/sonar/plugins/scmstats/ScmConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/scmstats/ScmConfigurationTest.java
@@ -19,26 +19,21 @@
  */
 package org.sonar.plugins.scmstats;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.maven.model.Scm;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.scm.provider.svn.svnexe.SvnExeScmProvider;
 import org.junit.*;
-import org.sonar.api.resources.Project;
+import org.sonar.api.config.Settings;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class ScmConfigurationTest {
-  private final Project myProject = new Project("myProject");
+  private final Settings settings = new Settings();
   private static final String URL = "scm:svn:http://";
   @Before
   public void setUp() {
-    
-    myProject.setConfiguration(mock(Configuration.class));
-    when(myProject.getConfiguration().getBoolean(ScmStatsPlugin.ENABLED, ScmStatsPlugin.ENABLED_DEFAULT)).thenReturn(true);
+    settings.setProperty(ScmStatsPlugin.ENABLED, true);
   }
 
   @Test
@@ -50,7 +45,7 @@ public class ScmConfigurationTest {
     scm.setDeveloperConnection(URL);
     mvnProject.setScm(scm);
     MavenScmConfiguration mavenConfonfiguration = new MavenScmConfiguration(mvnProject);
-    ScmConfiguration scmConfiguration = new ScmConfiguration(myProject.getConfiguration(), mavenConfonfiguration);
+    ScmConfiguration scmConfiguration = new ScmConfiguration(settings, mavenConfonfiguration);
     
     assertThat ( scmConfiguration.isEnabled() , is(true));
     assertThat ( scmConfiguration.getUrl() , is(URL));
@@ -59,7 +54,7 @@ public class ScmConfigurationTest {
 
   @Test
   public void testNonMavenConfiguration() {
-    ScmConfiguration scmConfiguration = new ScmConfiguration(myProject.getConfiguration());
+    ScmConfiguration scmConfiguration = new ScmConfiguration(settings);
     
     assertThat ( scmConfiguration.isEnabled() , is(true));
     assertNull ( scmConfiguration.getUrl());
@@ -68,9 +63,8 @@ public class ScmConfigurationTest {
 
   @Test
   public void testConfigurationOfSCMActivityPlugin() {
-    when(myProject.getConfiguration().getString("sonar.scm.url")).thenReturn(URL);
-
-    ScmConfiguration scmConfiguration = new ScmConfiguration(myProject.getConfiguration());
+    settings.setProperty("sonar.scm.url", URL);
+    ScmConfiguration scmConfiguration = new ScmConfiguration(settings);
     
     assertThat ( scmConfiguration.isEnabled() , is(true));
     assertThat ( scmConfiguration.getUrl() , is(URL));

--- a/src/test/java/org/sonar/plugins/scmstats/ScmStatsSensorTest.java
+++ b/src/test/java/org/sonar/plugins/scmstats/ScmStatsSensorTest.java
@@ -19,15 +19,9 @@
  */
 package org.sonar.plugins.scmstats;
 
-import org.apache.commons.configuration.Configuration;
 import org.junit.*;
-import static org.junit.Assert.*;
-import org.sonar.api.batch.SensorContext;
+import org.sonar.api.config.Settings;
 import org.sonar.api.resources.Project;
-import org.sonar.api.resources.Project;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -35,14 +29,13 @@ public class ScmStatsSensorTest {
 
   private ScmStatsSensor sensor;
   private final Project myProject = new Project("myProject");
-  private static final String URL = "scm:svn:http://";
+  private final Settings settings = new Settings();
 
   @Before
   public void setUp() {
-    myProject.setConfiguration(mock(Configuration.class));
     myProject.setLatestAnalysis(true);
-    when(myProject.getConfiguration().getBoolean(ScmStatsPlugin.ENABLED, ScmStatsPlugin.ENABLED_DEFAULT)).thenReturn(true);
-    ScmConfiguration scmConfiguration = new ScmConfiguration(myProject.getConfiguration());
+    settings.setProperty(ScmStatsPlugin.ENABLED, true);
+    ScmConfiguration scmConfiguration = new ScmConfiguration(settings);
     sensor = new ScmStatsSensor(scmConfiguration, new UrlChecker(), new ScmFacade(null, scmConfiguration));
   }
 
@@ -59,7 +52,7 @@ public class ScmStatsSensorTest {
 
   @Test
   public void testShouldNotExecuteOnProject_WhenPluginIsNotEnabled() {
-    when(myProject.getConfiguration().getBoolean(ScmStatsPlugin.ENABLED, ScmStatsPlugin.ENABLED_DEFAULT)).thenReturn(false);
+    settings.setProperty(ScmStatsPlugin.ENABLED, false);
     assertThat(sensor.shouldExecuteOnProject(myProject), is(false));
   }
 }


### PR DESCRIPTION
Update sonar.minversion to 3.0 and stop using deprecated commons-configuration within sonar-scm-stats. Migrate to org.sonar.api.config.Settings instead.

Manually disabled/enabled the SCM Stats plugin using the UI and confirmed it continued to behave as expected.
