### PR TITLE
Fix for https://groups.google.com/forum/#!topic/sonarqube/HspG8z2rBRo 

### DIFF
--- a/src/main/java/org/sonar/plugins/scmstats/ScmStatsPlugin.java
+++ b/src/main/java/org/sonar/plugins/scmstats/ScmStatsPlugin.java
@@ -55,6 +55,26 @@ public final class ScmStatsPlugin extends SonarPlugin {
               type(PropertyType.BOOLEAN).
               build(),
             
+            PropertyDefinition.builder(ScmStatsConstants.USER).
+              defaultValue("").
+              name("SCM Username").
+              description("SCM Usernaame").
+              index(1).
+              onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE).
+              category(SCMSTATS_CATEGORY).
+              type(PropertyType.STRING).
+              build(),
+            
+            PropertyDefinition.builder(ScmStatsConstants.PASSWORD).
+              defaultValue("").
+              name("SCM Password").
+              description("SCM Password").
+              index(1).
+              onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE).
+              category(SCMSTATS_CATEGORY).
+              type(PropertyType.PASSWORD).
+              build(),
+            
             PropertyDefinition.builder(ScmStatsConstants.PERIOD_1).
               defaultValue("0").
               name("Period #1").

--- a/src/test/java/org/sonar/plugins/scmstats/ScmStatsPluginTest.java
+++ b/src/test/java/org/sonar/plugins/scmstats/ScmStatsPluginTest.java
@@ -33,6 +33,6 @@ public class ScmStatsPluginTest {
 
   @Test
   public void testPluginDefinition() {
-    assertThat(plugin.getExtensions()).hasSize(25);
+    assertThat(plugin.getExtensions()).hasSize(27);
   }
 }


### PR DESCRIPTION
added sonar.scm.user.secured and sonar.scm.password.secured to properies for plugin.  Altered unit tests to accept 27 instead of 25 extensions.

Since SCM Activity is now deprecated for newer versions of SonarQube the sonar,scm.user.secured and sonar.scm.password.secured properties are no longer in use.  These can now be controlled by SCM Stats directly and allow this plugin to be used on SonarQube 5.1.2 and greater.

