### PR TITLE
Fixing squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/sonar/plugins/scmstats/ScmStatsConstants.java
+++ b/src/main/java/org/sonar/plugins/scmstats/ScmStatsConstants.java
@@ -24,8 +24,6 @@ import java.util.List;
 
 public final class ScmStatsConstants {
 
-  private ScmStatsConstants() {
-  }
   // Properties provided by this plugin
   public static final String ENABLED = "sonar.scm-stats.enabled";
   public static final String PERIOD_1 = "sonar.scm-stats.period1";
@@ -35,15 +33,20 @@ public final class ScmStatsConstants {
   public static final String MERGE_AUTHORS_LIST = "sonar.scm-stats.authors.merge";
   public static final String CHANGELOG_DATE_PATTERN = "sonar.scm-stats.changelog.datepattern";
   public static final String PERFORCE_CLIENTSPEC = "sonar.scm-stats.perforce.clientspec";
+  
   // Properties provided by the SCM Activity plugin
   public static final String URL = "sonar.scm.url";
   public static final String USER = "sonar.scm.user.secured";
   public static final String PASSWORD = "sonar.scm.password.secured";
+  
   // Constants used in the plugin
   public static final String ACTIVITY_ADD = "Adding";
   public static final String ACTIVITY_MODIFY = "Modifying";
   public static final String ACTIVITY_DELETE = "Deleting";
   public static final String HG_DEFAULT_CHANGELOG_DATE_PATTERN = "EEE MMM dd HH:mm:ss yyyy Z";
+  
+  private ScmStatsConstants() {
+  }
 
   public static List<String> getAsList() {
     return ImmutableList.of(ENABLED, PERIOD_1, PERIOD_2, PERIOD_3, URL, USER, PASSWORD,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1213


Please let me know if you have any questions.
Sameer Misger