### PR TITLE
Fixing squid:S2275 -Fixing squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/org/sonar/plugins/scmstats/AbstractScmAdapter.java
+++ b/src/main/java/org/sonar/plugins/scmstats/AbstractScmAdapter.java
@@ -83,7 +83,7 @@ public abstract class AbstractScmAdapter implements BatchExtension {
   protected Map<String, Integer> updateActivity (String resourceName, Map<String, Integer> fileStatus, String activity) {
     Resource resource = createResource(resourceName);
     LOG.warn(resource.getKey() + " is " + (isIncluded(resource) ? "NOT " : " ") + "excluded");
-    return (isIncluded(resource) ? MapUtils.updateMap(fileStatus, activity) : fileStatus);
+    return isIncluded(resource) ? MapUtils.updateMap(fileStatus, activity) : fileStatus;
   }
   
   Resource createResource(String resourceName) {

--- a/src/main/java/org/sonar/plugins/scmstats/HgScmAdapter.java
+++ b/src/main/java/org/sonar/plugins/scmstats/HgScmAdapter.java
@@ -86,7 +86,7 @@ public class HgScmAdapter extends AbstractScmAdapter {
       LOG.info("Getting change log information for %s\n", baseDir.getAbsolutePath());
       if (!hgRepo.initFrom(baseDir)) {
         throw new HgRepositoryNotFoundException(
-                String.format("Can't find repository in: %s\n",baseDir.getAbsolutePath()));
+                String.format("Can't find repository in: %s%n",baseDir.getAbsolutePath()));
       }
       HgLogCommand cmd = hgRepo.createLogCommand();
       return cmd.execute();

--- a/src/main/java/org/sonar/plugins/scmstats/measures/ChangeLogHandler.java
+++ b/src/main/java/org/sonar/plugins/scmstats/measures/ChangeLogHandler.java
@@ -90,7 +90,7 @@ public class ChangeLogHandler {
     authorActivity.putAll(map);
 
     final Map<String, Integer> activity = changeLogInfo.getActivity();
-    List<Integer> stats = (authorActivity.get(author) == null ? getInitialActivity(activity) : authorActivity.get(author).getCommits());
+    List<Integer> stats = authorActivity.get(author) == null ? getInitialActivity(activity) : authorActivity.get(author).getCommits();
 
     if (authorActivity.containsKey(author)) {
       final Integer commits = stats.get(0) + 1;

--- a/src/main/java/org/sonar/plugins/scmstats/utils/UrlChecker.java
+++ b/src/main/java/org/sonar/plugins/scmstats/utils/UrlChecker.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.sonar.api.BatchExtension;
 
 public class UrlChecker implements BatchExtension {
-  public static final String PARAMETER_MESSAGE = String.format("SCM Stats Plugin will not run.Please check the parameter SCM URL or the <scm> section of Maven pom.");
+  public static final String PARAMETER_MESSAGE = "SCM Stats Plugin will not run.Please check the parameter SCM URL or the <scm> section of Maven pom.";
   public static final String FAILURE_BLANK = "SCM URL must not be blank";
   public static final String FAILURE_FORMAT = "URL does not respect the SCM URL format described in http://maven.apache.org/scm/scm-url-format.html: [%s]";
   public static final String FAILURE_NOT_SUPPORTED = "Unsupported SCM: [%s]. Check compatibility at http://docs.codehaus.org/display/SONAR/SCM+Stats+Plugin";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding, squid:S1155 -  Printf-style format strings should not lead to unexpected behavior at runtime. You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S2275
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger